### PR TITLE
Add explicit "create_ca" bool

### DIFF
--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -13,14 +13,14 @@
 
 # Kubernetes CA (tls/{ca.crt,ca.key})
 resource "tls_private_key" "kube-ca" {
-  count = "${var.ca_certificate == "" ? 1 : 0}"
+  count = "${var.create_ca == 1 ? 1 : 0}"
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "kube-ca" {
-  count = "${var.ca_certificate == "" ? 1 : 0}"
+  count = "${var.create_ca == 1 ? 1 : 0}"
 
   key_algorithm   = "${tls_private_key.kube-ca.algorithm}"
   private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "trusted_certs_dir" {
 }
 
 variable "create_ca" {
-  description = "Toggles creation of a CA (when ca_certificate is omitted)"
+  description = "Toggles creation of a CA (omit ca_certificate when true)"
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,17 @@ variable "trusted_certs_dir" {
   default     = "/usr/share/ca-certificates"
 }
 
+variable "create_ca" {
+  description = "Toggles creation of a CA (when ca_certificate is omitted)"
+  default     = true
+}
+
+variable "ca_certificate" {
+  description = "Existing PEM-encoded CA certificate (generated if blank)"
+  type        = "string"
+  default     = ""
+}
+
 variable "ca_certificate" {
   description = "Existing PEM-encoded CA certificate (generated if blank)"
   type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -92,12 +92,6 @@ variable "ca_certificate" {
   default     = ""
 }
 
-variable "ca_certificate" {
-  description = "Existing PEM-encoded CA certificate (generated if blank)"
-  type        = "string"
-  default     = ""
-}
-
 variable "ca_key_alg" {
   description = "Algorithm used to generate ca_key (required if ca_cert is specified)"
   type        = "string"


### PR DESCRIPTION
In order to allow the user to pass in a CA cert or otherwise autogenerate one, this module uses the following:

```tf
count = "${var.ca_certificate == "" ? 1 : 0}"
```

That works fine if you pass in the ca cert as a string, but not if it's dynamic. If it's dynamic you run into this: https://github.com/hashicorp/terraform/issues/17421

In https://github.com/TakeScoop/kubernetes/pull/60, we're passing this in as the result of https://github.com/TakeScoop/kubernetes/blob/master/modules/ca/main.tf#L7-L25

This means that terraform can't figure out whether it should create the CA cert here at plan time and fails with an error. I've added this `create_ca` var that can be set statically to determine count. Then the actual CA cert can be passed dynamically with no problem.