### PR TITLE
Enable audit logging for apiserver

### DIFF
--- a/resources/manifests/kube-apiserver-config.yaml
+++ b/resources/manifests/kube-apiserver-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+data:
+  audit.yaml: |-
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -41,6 +41,8 @@ spec:
         - --advertise-address=$(POD_IP)
         - --allow-privileged=true
         - --anonymous-auth=false
+        - --audit-log-path=-
+        - --audit-policy-file=/etc/kubernetes/config/audit.yaml
         - --authorization-mode=RBAC
         - --bind-address=0.0.0.0
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
@@ -70,6 +72,9 @@ spec:
         - name: secrets
           mountPath: /etc/kubernetes/secrets
           readOnly: true
+        - name: config
+          mountPath: /etc/kubernetes/config
+          readOnly: true
         - name: ssl-certs-host
           mountPath: /etc/ssl/certs
           readOnly: true
@@ -77,6 +82,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-apiserver
+      - name: config
+        configMap:
+          name: kube-apiserver
       - name: ssl-certs-host
         hostPath:
           path: ${trusted_certs_dir}


### PR DESCRIPTION
Configures audit logging, as described by the [Kubernetes auditing guide](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/). 

* Creates a ConfigMap with an audit Policy document which configures what calls/properties will be logged
* Mounts that ConfigMap (read only) to `/etc/kubernetes/config`, such that each key becomes a file
* Specifies the included file as `--audit-policy-file` in apiserver's args
* Sets `--audit-log-path=-` so that audit logs are printed to stdout, along with all other logs produced by apiserver. This means that we'll collect these as part of our normal container log pipeline.

General notes:

* Extra audit logs beyond metadata can be handy. For example, when a user updates a Deployment, seeing the content of a "patch" is useful. For other objects (e.g. Secret), logging content can leak data. For now, I didn't want to make a resource-by-resource evaluation of what we should log.
* Logs are in JSON