### PR TITLE
Fix TF core version bump

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.0, <= 0.14"
+  required_version = ">= 0.12.0, < 0.15"
   required_providers {
     random   = "~> 2.2"
     template = "~> 2.1"


### PR DESCRIPTION
Sadly, it looks like <= 0.14 does not allow for 0.14.11. 

https://terraform.takescoop.com/app/takescoop/workspaces/kubernetes-staging/runs/run-WLCYDK4WeW4L2SYB

lesson learned, go with the fool proof configuration